### PR TITLE
fixed bug where hamburger navbar appear below img

### DIFF
--- a/src/components/nav/NavHamburg.astro
+++ b/src/components/nav/NavHamburg.astro
@@ -13,9 +13,8 @@ const navLinks = {
 }
 ---
 
-<!--- TODO: Hamburger navbar is VERY buggy with hover effects on Tailwind. Rewrite component -->
 <!-- Hamburger style navbar for mobile devices -->
-<nav id="navbar" class="fixed right-0 flex flex-col items-end md:hidden">
+<nav id="navbar" class="fixed right-0 flex flex-col items-end md:hidden z-40">
     <input id="burger-checkbox" type="checkbox" name="" class="hidden" />
     <div id="hamburger-lines" class="h-6 w-8 flex flex-col justify-between cursor-pointer absolute top-12 right-8 z-50">
         <span id="hamburger-line-1" class="block h-1 w-full rounded-lg bg-white transition-transform"></span>


### PR DESCRIPTION
Fixed bug where the hamburger (mobile) navbar will appear bellow images with interactive styles. Simple z-index manipulation.