### PR TITLE
Refactor to include an index live site as well as a countdown live site

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,13 +1,21 @@
 ---
 interface Props {
-  siteState: string;
+  siteState: "registration" | "post-registration" | "live" | "live.countdown";
 }
 
 const { siteState } = Astro.props; // for updating content depending on the stage of the hackathon
-let title = "Revolution".toUpperCase();
-let date = "    February 24-25    ".toUpperCase(); // Keep the space in order to match with the RevolutionUC Text
-let subText = "Registration opens in:";
-let liveSubText = "   Hacking ends in:   ";
+
+const heading = "Revolution";
+const date = "    February 24-25    "; // Keep the space in order to match with the RevolutionUC Text
+const liveCountdownSubheading = "   Hacking ends in:   ";
+const subheading = siteState !== "live.countdown" ? date : liveCountdownSubheading;
+const ctaTextBySiteState: Record<typeof siteState, string> = {
+  live: "Live site",
+  registration: "Register",
+  "live.countdown": "##:##:##",
+  "post-registration": "Our Devpost"
+};
+const ctaText = ctaTextBySiteState[siteState];
 ---
 
 <!--- Post-register site --><!--- <section id="hero" class="h-screen flex flex-col justify-center items-center space-y-4 bg-black">
@@ -27,11 +35,11 @@ let liveSubText = "   Hacking ends in:   ";
     </div>
     <div class="grid grid-cols-22 gap-2 w-4/5 max-[1024px]:w-11/12 desktop text-white">
       {
-        Array.from(title).map((letter) => {
+        Array.from(heading).map((letter) => {
           if (letter === " ") return <div />;
           return (
             <div
-              class="row-span-2 col-span-2 text-6xl max-[1024px]:text-lg font-extrabold flex justify-center items-center border shadow-2xl cursor-default min-[1024px]:backdrop-blur-sm transition-transform active:scale-[0.98] hover:scale-[1.02]"
+              class="uppercase row-span-2 col-span-2 text-6xl max-[1024px]:text-lg font-extrabold flex justify-center items-center border shadow-2xl cursor-default min-[1024px]:backdrop-blur-sm transition-transform active:scale-[0.98] hover:scale-[1.02]"
               data-text={letter}
             >
               <span>{letter}</span>
@@ -50,58 +58,26 @@ let liveSubText = "   Hacking ends in:   ";
         />
       </div>
       {
-        Array.from(date).map((letter) => {
-          if (siteState !== "live") {
-            if (letter === " ") return <div />;
-            return (
-              <div
-                class="text-4xl max-[1024px]:text-lg min-[1024px]:border font-extrabold flex justify-center items-center shadow-2xl cursor-default backdrop-blur-sm"
-                data-text={letter}
-              >
-                <span>{letter}</span>
-              </div>
-            );
-          }
-        })
-      }
-      {
-        Array.from(subText).map((letter) => {
-          if (siteState === "pre-registration") {
-            if (letter === " ") return <div />;
-            return (
-              <div
-                class="text-4xl max-[1024px]:text-lg min-[1024px]:border font-extrabold flex justify-center items-center shadow-2xl cursor-default backdrop-blur-sm"
-                data-text={letter}
-              >
-                <span>{letter}</span>
-              </div>
-            );
-          }
-        })
-      }
-      { 
-        Array.from(liveSubText).map((letter) => {
-          if (siteState === "live") {
-            if (letter === " ") return <div />;
-            return (
-              <div
-                class="text-4xl max-[1024px]:text-lg min-[1024px]:border font-extrabold flex justify-center items-center shadow-2xl cursor-default backdrop-blur-sm"
-                data-text={letter}
-              >
-                <span>{letter}</span>
-              </div>
-            );
-          }
+        Array.from(subheading).map((letter) => {
+          if (letter === " ") return <div />;
+          return (
+            <div
+              class="uppercase text-4xl max-[1024px]:text-lg min-[1024px]:border font-extrabold flex justify-center items-center shadow-2xl cursor-default backdrop-blur-sm"
+              data-text={letter}
+            >
+              <span>{letter}</span>
+            </div>
+          );
         })
       }
 
       <div class="col-span-12 h-[2vw]"></div>
       <a
         id="register-button"
-        class="col-start-8 col-span-8 text-[3vw] max-[1024px]:text-[5vw] tracking-widest font-extrabold border-2 flex justify-center items-center cursor-pointer shadow-2xl backdrop-blur-sm transition-all active:scale-[0.99] hover:scale-[1.01] hover:bg-white hover:text-[#f75c03] hover:backdrop-blur-[6px] active:shadow-lg"
-        href={siteState === "registration" ? "/registration" : "#"}
+        class="uppercase col-start-8 col-span-8 text-[3vw] max-[1024px]:text-[5vw] tracking-widest font-extrabold border-2 flex justify-center items-center cursor-pointer shadow-2xl backdrop-blur-sm transition-all active:scale-[0.99] hover:scale-[1.01] hover:bg-white hover:text-[#f75c03] hover:backdrop-blur-[6px] active:shadow-lg"
+        href={siteState === "registration" ? "/registration" : siteState === "live" ? "/live" : "#"}
       >
-        <span>{siteState === "registration" ? "REGISTER" : "##:##:##"}</span>
+        <span>{ctaText}</span>
       </a>
     </div>
   </div>
@@ -112,7 +88,9 @@ let liveSubText = "   Hacking ends in:   ";
     background-image: linear-gradient(#d80368 -12%, #f75c03 100%);
   }
   #landscape-grid {
-    background-size: 5vh 5vh, 80px 80px;
+    background-size:
+      5vh 5vh,
+      80px 80px;
     background-image: linear-gradient(to bottom, #d80368 1.5px, transparent 1.5px),
       linear-gradient(to right, #d80368 1.5px, transparent 1.5px);
     animation: moveUp 15s linear infinite forwards;
@@ -434,9 +412,9 @@ let liveSubText = "   Hacking ends in:   ";
       }
     }, 1000);
   }
-  // if siteState is live, start countdown until feb 25th 2024 12pm
-  if (siteState === "live") {
-    const countdown = document.querySelector("#register-button")
+  // if siteState is live.countdown, start countdown until feb 25th 2024 12pm EST -5
+  if (siteState === "live.countdown") {
+    const countdown = document.querySelector("#register-button");
 
     const interval = setInterval(() => {
       const now = new Date();
@@ -454,7 +432,5 @@ let liveSubText = "   Hacking ends in:   ";
         countdown.innerText = "REGISTER";
       }
     }, 1000);
-    
   }
-
 </script>

--- a/src/pages/_live.astro
+++ b/src/pages/_live.astro
@@ -12,21 +12,15 @@ import QuickLinks from "../components/QuickLinks.astro";
 <HTMLWrapper title="Home">
   <ResponsiveNav current="home" />
   <main>
-    <Hero siteState="live" />
-    <div class="grid grid-cols-1 2xl:grid-cols-5 mt-12 content-center p-8">
-      <div class="2xl:col-span-1 flex justify-center items-start 2xl:mt-12">
+    <Hero siteState="live.countdown" />
+    <div class="grid grid-cols-1 2xl:grid-cols-5 content-center p-8 mt-6">
+      <div class="2xl:col-span-1 flex justify-center mb-12">
         <QuickLinks />
       </div>
       <div class="2xl:col-span-3 flex flex-col justify-center items-center">
         <h2 class="text-5xl font-bold text-center">Schedule</h2>
-        <ScheduleTable
-          schedule={scheduleData.scheduleDayOne}
-          label="February 24th"
-        />
-        <ScheduleTable
-          schedule={scheduleData.scheduleDayTwo}
-          label="February 25th"
-        />
+        <ScheduleTable schedule={scheduleData.scheduleDayOne} label="February 24th" />
+        <ScheduleTable schedule={scheduleData.scheduleDayTwo} label="February 25th" />
       </div>
       <!-- Instagram Embed -->
       <div class="flex flex-col items-center max-[1800px]:hidden">
@@ -42,29 +36,20 @@ import QuickLinks from "../components/QuickLinks.astro";
               style=" background:#FFFFFF; line-height:0; padding:0 0; text-align:center; text-decoration:none; width:100%;"
               target="_blank"
             >
-              <div
-                style=" display: flex; flex-direction: row; align-items: center;"
-              >
+              <div style=" display: flex; flex-direction: row; align-items: center;">
                 <div
                   style="background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 40px; margin-right: 14px; width: 40px;"
                 >
                 </div>
-                <div
-                  style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center;"
-                >
+                <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center;">
                   <div
                     style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 100px;"
                   >
                   </div>
-                  <div
-                    style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 60px;"
-                  >
-                  </div>
+                  <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 60px;"></div>
                 </div>
               </div><div style="padding: 19% 0;"></div>
-              <div
-                style="display:block; height:50px; margin:0 auto 12px; width:50px;"
-              >
+              <div style="display:block; height:50px; margin:0 auto 12px; width:50px;">
                 <svg
                   width="50px"
                   height="50px"
@@ -72,21 +57,16 @@ import QuickLinks from "../components/QuickLinks.astro";
                   version="1.1"
                   xmlns="https://www.w3.org/2000/svg"
                   xmlns:xlink="https://www.w3.org/1999/xlink"
-                  ><g
-                    stroke="none"
-                    stroke-width="1"
-                    fill="none"
-                    fill-rule="evenodd"
-                    ><g
-                      transform="translate(-511.000000, -20.000000)"
-                      fill="#000000"
+                  ><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"
+                    ><g transform="translate(-511.000000, -20.000000)" fill="#000000"
                       ><g
                         ><path
                           d="M556.869,30.41 C554.814,30.41 553.148,32.076 553.148,34.131 C553.148,36.186 554.814,37.852 556.869,37.852 C558.924,37.852 560.59,36.186 560.59,34.131 C560.59,32.076 558.924,30.41 556.869,30.41 M541,60.657 C535.114,60.657 530.342,55.887 530.342,50 C530.342,44.114 535.114,39.342 541,39.342 C546.887,39.342 551.658,44.114 551.658,50 C551.658,55.887 546.887,60.657 541,60.657 M541,33.886 C532.1,33.886 524.886,41.1 524.886,50 C524.886,58.899 532.1,66.113 541,66.113 C549.9,66.113 557.115,58.899 557.115,50 C557.115,41.1 549.9,33.886 541,33.886 M565.378,62.101 C565.244,65.022 564.756,66.606 564.346,67.663 C563.803,69.06 563.154,70.057 562.106,71.106 C561.058,72.155 560.06,72.803 558.662,73.347 C557.607,73.757 556.021,74.244 553.102,74.378 C549.944,74.521 548.997,74.552 541,74.552 C533.003,74.552 532.056,74.521 528.898,74.378 C525.979,74.244 524.393,73.757 523.338,73.347 C521.94,72.803 520.942,72.155 519.894,71.106 C518.846,70.057 518.197,69.06 517.654,67.663 C517.244,66.606 516.755,65.022 516.623,62.101 C516.479,58.943 516.448,57.996 516.448,50 C516.448,42.003 516.479,41.056 516.623,37.899 C516.755,34.978 517.244,33.391 517.654,32.338 C518.197,30.938 518.846,29.942 519.894,28.894 C520.942,27.846 521.94,27.196 523.338,26.654 C524.393,26.244 525.979,25.756 528.898,25.623 C532.057,25.479 533.004,25.448 541,25.448 C548.997,25.448 549.943,25.479 553.102,25.623 C556.021,25.756 557.607,26.244 558.662,26.654 C560.06,27.196 561.058,27.846 562.106,28.894 C563.154,29.942 563.803,30.938 564.346,32.338 C564.756,33.391 565.244,34.978 565.378,37.899 C565.522,41.056 565.552,42.003 565.552,50 C565.552,57.996 565.522,58.943 565.378,62.101 M570.82,37.631 C570.674,34.438 570.167,32.258 569.425,30.349 C568.659,28.377 567.633,26.702 565.965,25.035 C564.297,23.368 562.623,22.342 560.652,21.575 C558.743,20.834 556.562,20.326 553.369,20.18 C550.169,20.033 549.148,20 541,20 C532.853,20 531.831,20.033 528.631,20.18 C525.438,20.326 523.257,20.834 521.349,21.575 C519.376,22.342 517.703,23.368 516.035,25.035 C514.368,26.702 513.342,28.377 512.574,30.349 C511.834,32.258 511.326,34.438 511.181,37.631 C511.035,40.831 511,41.851 511,50 C511,58.147 511.035,59.17 511.181,62.369 C511.326,65.562 511.834,67.743 512.574,69.651 C513.342,71.625 514.368,73.296 516.035,74.965 C517.703,76.634 519.376,77.658 521.349,78.425 C523.257,79.167 525.438,79.673 528.631,79.82 C531.831,79.965 532.853,80.001 541,80.001 C549.148,80.001 550.169,79.965 553.369,79.82 C556.562,79.673 558.743,79.167 560.652,78.425 C562.623,77.658 564.297,76.634 565.965,74.965 C567.633,73.296 568.659,71.625 569.425,69.651 C570.167,67.743 570.674,65.562 570.82,62.369 C570.966,59.17 571,58.147 571,50 C571,41.851 570.966,40.831 570.82,37.631"
                         ></path></g
                       ></g
                     ></g
-                  ></svg>
+                  ></svg
+                >
               </div><div style="padding-top: 8px;">
                 <div
                   style=" color:#3897f0; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:550; line-height:18px;"
@@ -94,9 +74,7 @@ import QuickLinks from "../components/QuickLinks.astro";
                   View this profile on Instagram
                 </div>
               </div><div style="padding: 12.5% 0;"></div>
-              <div
-                style="display: flex; flex-direction: row; margin-bottom: 14px; align-items: center;"
-              >
+              <div style="display: flex; flex-direction: row; margin-bottom: 14px; align-items: center;">
                 <div>
                   <div
                     style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(0px) translateY(7px);"
@@ -111,10 +89,7 @@ import QuickLinks from "../components/QuickLinks.astro";
                   >
                   </div>
                 </div><div style="margin-left: 8px;">
-                  <div
-                    style=" background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 20px; width: 20px;"
-                  >
-                  </div>
+                  <div style=" background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 20px; width: 20px;"></div>
                   <div
                     style=" width: 0; height: 0; border-top: 2px solid transparent; border-left: 6px solid #f4f4f4; border-bottom: 2px solid transparent; transform: translateX(16px) translateY(-4px) rotate(30deg)"
                   >
@@ -124,9 +99,7 @@ import QuickLinks from "../components/QuickLinks.astro";
                     style=" width: 0px; border-top: 8px solid #F4F4F4; border-right: 8px solid transparent; transform: translateY(16px);"
                   >
                   </div>
-                  <div
-                    style=" background-color: #F4F4F4; flex-grow: 0; height: 12px; width: 16px; transform: translateY(-4px);"
-                  >
+                  <div style=" background-color: #F4F4F4; flex-grow: 0; height: 12px; width: 16px; transform: translateY(-4px);">
                   </div>
                   <div
                     style=" width: 0; height: 0; border-top: 8px solid #F4F4F4; border-left: 8px solid transparent; transform: translateY(-4px) translateX(8px);"
@@ -134,17 +107,12 @@ import QuickLinks from "../components/QuickLinks.astro";
                   </div>
                 </div>
               </div>
-              <div
-                style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center; margin-bottom: 24px;"
-              >
+              <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center; margin-bottom: 24px;">
                 <div
                   style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 224px;"
                 >
                 </div>
-                <div
-                  style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 144px;"
-                >
-                </div>
+                <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 144px;"></div>
               </div></a
             ><p
               style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;"
@@ -164,18 +132,10 @@ import QuickLinks from "../components/QuickLinks.astro";
         <script async src="//www.instagram.com/embed.js"></script>
       </div>
     </div>
-    <div
-      class="2xl:row-start-2 2xl:col-2 flex flex-col justify-center items-center py-8"
-    >
+    <div class="2xl:row-start-2 2xl:col-2 flex flex-col justify-center items-center py-8">
       <h2 class="text-5xl font-bold mb-4 text-center">Shuttle Schedule</h2>
-      <ScheduleTable
-        schedule={shuttleData.scheduleDayOne}
-        label="February 24th"
-      />
-      <ScheduleTable
-        schedule={shuttleData.scheduleDayTwo}
-        label="February 25th"
-      />
+      <ScheduleTable schedule={shuttleData.scheduleDayOne} label="February 24th" />
+      <ScheduleTable schedule={shuttleData.scheduleDayTwo} label="February 25th" />
     </div>
   </main>
   <Footer />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,17 +6,17 @@ import Description from "../components/Description.astro";
 import PastHacks from "../components/PastHacks.astro";
 import Footer from "../components/Footer.astro";
 
-import siteConfigData from "../data/config.json";
+const siteState = "live"
 
-if (siteConfigData.timeline === "live") {
-  return Astro.redirect('/live');
-}
+// if (siteState === "live") {
+//   return Astro.redirect('/live');
+// }
 ---
 
 <HTMLWrapper title="Home">
   <ResponsiveNav current="home" />
   <main>
-    <Hero siteState="registration" />
+    <Hero siteState={siteState} />
     <Description />
     <PastHacks />
   </main>


### PR DESCRIPTION
Now the index page has a `siteState` of `live`, with the CTA button text saying "Live Site", whereas the `/live` page now has `siteState` of `live.countdown`, with button text replaced by a countdown.

Also remove automatic redirection from "/" to "/live" because maybe people still want to see the original home page.